### PR TITLE
Create 0012-separate-cms-context-from-ui-provider.md

### DIFF
--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -86,3 +86,7 @@ export function EditButton() {
   )
 }
 ```
+
+## Conclusion
+
+For general use cases, this will require no change in our docs. But for advanced use cases, such as an enterprise trying to separate all write logic from their production endpoints, this will make this trivial to do.

--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -72,7 +72,7 @@ export function Admin() {
     <TinaUI>
       <EditButton />
       {...logic to render app}
-    </TinaUIProvider>
+    </TinaUI>
   )
 }
 ```

--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -68,7 +68,7 @@ export function MyApp({Component, pageProps}) {
 ```
 export function Admin({editMode}) {
   return (
-    <TinaUIProvider editing={editMode}>
+    <TinaUI editing={editMode}>
       {...logic to render app}
     </TinaUIProvider>
   )

--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -29,27 +29,27 @@ The TinaCMSProvider will take responsibility for holding the instance of the CMS
 
 
 ```
-export function MyApp() {
+export function MyApp({children}) {
  const cms = useMemo(() => new TinaCMS());
  
  return (
    <TinaCMSProvider cms={cms}>
-     {...}
+     {children}
    </TinaCMSProvider>
  )
 }
 ```
 
-### The TinaUIProvider
+### The TinaUI Provider
 
-The `TinaUIProvider` will take responsibility for rendering the Tina React UI, and UI context.
+The `TinaUI` Provider will take responsibility for rendering the Tina React UI, and UI context.
 
 This will allow a user to wrap a sub-section of an application devoted to editing with editing logic, while leaving the `TinaCMSProvider` at the top of the application tree. This approach will greatly reduce bundle sizes by only importing and downloading Tina UI on routes that need it.
 
 
 ### Changes to TinaProvider
 
-The API of `TinaProvider` wont change, but under the hood, it will now setup the `TinaCMSProvider` and `TinaUIProvider` for the user, leading to 0 breaking changes.
+The API of `TinaProvider` wont change, but under the hood, it will now setup the `TinaCMSProvider` and `TinaUI` for the user, leading to 0 breaking changes.
 
 ## Next.js Example
 
@@ -59,16 +59,17 @@ export function MyApp({Component, pageProps}) {
  
  return (
    <TinaCMSProvider cms={cms}>
-     {...}
+     <Component {...pageProps} />
    </TinaCMSProvider>
  )
 }
 ```
 
 ```
-export function Admin({editMode}) {
+export function Admin() {
   return (
-    <TinaUI editing={editMode}>
+    <TinaUI>
+      <EditButton />
       {...logic to render app}
     </TinaUIProvider>
   )

--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -25,7 +25,7 @@ I propose we add a few new APIs to support advanced use cases...
 
 ### The TinaCMSProvider
 
-The TinaCMSProvider will take responsibility for holding the instance of the CMS in context, and is the `useCMS` hook will fetch context. This can wrap the entire React app while having almost 0 impact on bundle size:
+The TinaCMSProvider will take responsibility for holding the instance of the CMS in context, and is what the `useCMS` hook will fetch context under the hood. This can wrap the entire React app while having almost 0 impact on bundle size:
 
 
 ```
@@ -44,7 +44,7 @@ export function MyApp() {
 
 The `TinaUIProvider` will take responsibility for rendering the Tina React UI, and UI context.
 
-This will allow a user to wrap a sub-section of an application devoted to editing with editing logic, while leaving the `TinaCMSProvider` at the top of the application tree.
+This will allow a user to wrap a sub-section of an application devoted to editing with editing logic, while leaving the `TinaCMSProvider` at the top of the application tree. This approach will greatly reduce bundle sizes by only importing and downloading Tina UI on routes that need it.
 
 
 ### Changes to TinaProvider

--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -1,0 +1,88 @@
+---
+title: Separating the CMS Instance Context from UI and UI Contex
+---
+
+Currently in a React app, we setup Tina by using:
+
+- `withTina`
+- `TinaProvider`
+
+In both cases, these utilities:
+
+- Wrap the app with a configured instance of TinaCMS stored in context
+- Wrap the app with the TinaCMS UI, UI context, and business context
+
+This is problematic for a few reasons:
+
+- It's not possible to wrap an app with an instance of Tina without downloading all of the Tina React UI, UI context, and business logic.
+- It's not possible to use Tina logic in app without downloading all of the React UI, UI context, and business logic.
+
+## Propose API
+
+I don't propose we change the existing API. It is the "simplest" use case.
+
+I propose we add a few new APIs to support advanced use cases...
+
+### The TinaCMSProvider
+
+The TinaCMSProvider will take responsibility for holding the instance of the CMS in context, and is the `useCMS` hook will fetch context. This can wrap the entire React app while having almost 0 impact on bundle size:
+
+
+```
+export function MyApp() {
+ const cms = useMemo(() => new TinaCMS());
+ 
+ return (
+   <TinaCMSProvider cms={cms}>
+     {...}
+   </TinaCMSProvider>
+ )
+}
+```
+
+### The TinaUIProvider
+
+The `TinaUIProvider` will take responsibility for rendering the Tina React UI, and UI context.
+
+This will allow a user to wrap a sub-section of an application devoted to editing with editing logic, while leaving the `TinaCMSProvider` at the top of the application tree.
+
+
+### Changes to TinaProvider
+
+The API of `TinaProvider` wont change, but under the hood, it will now setup the `TinaCMSProvider` and `TinaUIProvider` for the user, leading to 0 breaking changes.
+
+## Next.js Example
+
+```
+export function MyApp({Component, pageProps}) {
+ const cms = useMemo(() => new TinaCMS());
+ 
+ return (
+   <TinaCMSProvider cms={cms}>
+     {...}
+   </TinaCMSProvider>
+ )
+}
+```
+
+```
+export function Admin({editMode}) {
+  return (
+    <TinaUIProvider editing={editMode}>
+      {...logic to render app}
+    </TinaUIProvider>
+  )
+}
+```
+
+```
+export function EditButton() {
+  const cms = useCMS();
+  
+  return (
+    <button type="button" onClick={() => cms.enable()}>
+      {cms.enabled ? "Login" : "Logout"
+    </button>
+  )
+}
+```

--- a/0012-separate-cms-context-from-ui-provider.md
+++ b/0012-separate-cms-context-from-ui-provider.md
@@ -16,6 +16,7 @@ This is problematic for a few reasons:
 
 - It's not possible to wrap an app with an instance of Tina without downloading all of the Tina React UI, UI context, and business logic.
 - It's not possible to use Tina logic in app without downloading all of the React UI, UI context, and business logic.
+- The Tina UI adds around 150mb of JS to a page.
 
 ## Propose API
 


### PR DESCRIPTION
Requesting this, as some enterprise customers are struggling to structure a Next.js app to not send secure information to production, but want to send the CMS object to production without the TinaCMS react code. 